### PR TITLE
Raise when data is both specification and section

### DIFF
--- a/tests/parse/test_parse_vrplib.py
+++ b/tests/parse/test_parse_vrplib.py
@@ -231,6 +231,24 @@ def test_parse_vrplib_do_not_compute_edge_weights():
     assert_("edge_weight" not in actual)
 
 
+def test_parse_vrplib_raises_when_both_specification_and_section():
+    """
+    Tests if a ValueError is raised when a specification is also a section.
+    """
+    instance = "\n".join(
+        [
+            "SERVICE_TIME: 10",
+            "SERVICE_TIME_SECTION",
+            "1    20",
+            "2    20",
+        ]
+    )
+
+    # Service time is both a specification and a section which is not allowed.
+    with assert_raises(ValueError):
+        parse_vrplib(instance)
+
+
 def test_empty_text():
     """
     Tests if an empty text file is still read correctly.

--- a/tests/parse/test_parse_vrplib.py
+++ b/tests/parse/test_parse_vrplib.py
@@ -231,9 +231,10 @@ def test_parse_vrplib_do_not_compute_edge_weights():
     assert_("edge_weight" not in actual)
 
 
-def test_parse_vrplib_raises_when_both_specification_and_section():
+def test_parse_vrplib_raises_data_specification_and_section():
     """
-    Tests if a ValueError is raised when a specification is also a section.
+    Tests that a ValueError is raised when data is included both as
+    specification and section.
     """
     instance = "\n".join(
         [

--- a/vrplib/parse/parse_vrplib.py
+++ b/vrplib/parse/parse_vrplib.py
@@ -43,6 +43,12 @@ def parse_vrplib(text: str, compute_edge_weights: bool = True) -> Instance:
 
     for section in sections:
         section_name, data = parse_section(section, instance)
+
+        if section_name in instance:
+            name = section_name.upper()
+            msg = f"{name} is used both as a specification and a section."
+            raise ValueError(msg)
+
         instance[section_name] = data  # type: ignore
 
     if instance and compute_edge_weights and "edge_weight" not in instance:

--- a/vrplib/parse/parse_vrplib.py
+++ b/vrplib/parse/parse_vrplib.py
@@ -46,7 +46,7 @@ def parse_vrplib(text: str, compute_edge_weights: bool = True) -> Instance:
 
         if section_name in instance:
             name = section_name.upper()
-            msg = f"{name} is used both as a specification and a section."
+            msg = f"'{name}' is used both as a specification and a section."
             raise ValueError(msg)
 
         instance[section_name] = data  # type: ignore


### PR DESCRIPTION
This PR raises errors when parsing VRPLIB instances that uses the same keyword as specification and data section.